### PR TITLE
Fix dual-GPU visibility and identical-card preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.12'
       - name: Compile rc5 wrapper and frozen runtime adapters
         run: |
-          python -m py_compile __init__.py base_runtime.py h3vm/__init__.py h3vm/core_adapter.py h3vm/core_adapter_base.py h3vm/loader.py h3vm/loader_base.py h3vm/master_console.py h3vm/style_lora.py
+          python -m py_compile __init__.py base_runtime.py h3vm/__init__.py h3vm/core_adapter.py h3vm/core_adapter_base.py h3vm/gpu_preflight.py h3vm/loader.py h3vm/loader_base.py h3vm/master_console.py h3vm/style_lora.py
       # Run the lightweight assert-based contracts as scripts. This avoids pytest
       # treating the ComfyUI custom-node root __init__.py as a top-level package.
       - name: Run rc5 contracts directly
@@ -30,3 +30,4 @@ jobs:
           python tests/test_core_adapter_contract.py
           python tests/test_public_core_contract.py
           python tests/test_style_lora_contract.py
+          python tests/test_gpu_preflight_contract.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Fixed dual-GPU preflight so explicit `gpu:N` / `cuda:N` selections map to distinct PyTorch-logical CUDA devices before falling back to ComfyUI's resolver.
+- Identical GPU model names are explicitly supported; for example, two RTX 3080 cards are valid when both are visible to the current ComfyUI/Python process.
+- When fewer than two CUDA devices are visible, H3VM now reports `torch.cuda.device_count()` context, `CUDA_VISIBLE_DEVICES`, `NVIDIA_VISIBLE_DEVICES`, visible GPU names/VRAM, and a best-effort `nvidia-smi` physical inventory instead of the old generic “requires at least two CUDA GPUs” error.
+- Successful dual-GPU preflight now logs the resolved logical devices once, making visibility masks and same-model pairs easy to verify from the console.
+- The heavy proven runtime in `loader_base.py` remains untouched; the compatibility fix is installed before Core/loader wrappers bind runtime helpers.
+
 ## v0.20.0-rc5
 
 - Added public `H3VM Core｜多卡执行引擎`: pure `MODEL -> MODEL` integration node for external workflows.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,21 @@ MiniMax H3 多卡加载与显存调度节点。目标不是提供一条固定工
 
 默认节点菜单只显示公开使用节点，避免历史实验节点刷屏。开发者如需重新显示全部 Lab 节点，可在启动 ComfyUI 前设置环境变量 `H3VM_SHOW_LAB_NODES=1`。
 
+## 双卡识别与同型号显卡
+
+H3VM **不要求两张显卡型号不同**。两张 RTX 3080、两张 RTX 5060 Ti 等同型号组合都可以使用；判断依据是当前 ComfyUI/Python 进程是否能看到两个不同的 CUDA 逻辑设备，而不是显卡名称是否不同。
+
+双卡模式默认选择 `gpu:0` + `gpu:1`。这里的编号是 PyTorch 当前进程看到的**逻辑编号**。如果启动脚本设置了 `CUDA_VISIBLE_DEVICES`，物理卡会被过滤并重新编号。例如只设置 `CUDA_VISIBLE_DEVICES=0` 时，即使机器实际安装了两张卡，当前 ComfyUI 进程也只会看到一个 `cuda:0`，双卡模式无法工作；设置为 `CUDA_VISIBLE_DEVICES=0,1` 后再重启 ComfyUI，进程才会看到两个逻辑 CUDA 设备。
+
+新版 preflight 在失败时会直接打印：
+
+- `PyTorch-visible CUDA devices`
+- `CUDA_VISIBLE_DEVICES` / `NVIDIA_VISIBLE_DEVICES`
+- 当前可见 GPU 名称与显存
+- 失败时 best-effort 的 `nvidia-smi` 物理 GPU 列表
+
+成功时控制台会出现 `[H3VM GPU PREFLIGHT]`，并列出实际解析出的 primary / secondary。这样可以区分“机器有两张卡”和“当前 ComfyUI 只看见一张卡”。
+
 ## 推荐测试顺序
 
 第一次测试建议保持相同 Prompt / Seed / LoRA，只切模式：

--- a/README_EN.md
+++ b/README_EN.md
@@ -209,6 +209,21 @@ Developers can expose the lab nodes by setting this environment variable before 
 H3VM_SHOW_LAB_NODES=1
 ```
 
+## Dual-GPU detection and identical cards
+
+H3VM does **not** require two different GPU model names. Two RTX 3080 cards, two RTX 5060 Ti cards, and other identical-model pairs are valid. What matters is that the current ComfyUI/Python process can see two different CUDA **logical devices**.
+
+Dual-GPU modes normally select `gpu:0` + `gpu:1`. These are PyTorch-visible logical indices. If the startup environment sets `CUDA_VISIBLE_DEVICES`, physical GPUs can be filtered and renumbered. For example, `CUDA_VISIBLE_DEVICES=0` exposes only one logical `cuda:0` even if the machine physically contains two GPUs. Expose both target cards, for example with `CUDA_VISIBLE_DEVICES=0,1`, and restart ComfyUI before using a dual-GPU mode.
+
+The improved preflight reports:
+
+- the number of PyTorch-visible CUDA devices
+- `CUDA_VISIBLE_DEVICES` and `NVIDIA_VISIBLE_DEVICES`
+- visible GPU names and VRAM
+- a best-effort physical `nvidia-smi` inventory when preflight fails
+
+On success, the console prints `[H3VM GPU PREFLIGHT]` with the resolved primary and secondary devices. This makes it clear whether the machine lacks a second GPU or the current process is simply hiding it.
+
 ## Recommended first test
 
 For the first validation run, keep the same prompt, seed, model, LoRA, and resolution. Change only the GPU mode.

--- a/h3vm/__init__.py
+++ b/h3vm/__init__.py
@@ -1,4 +1,11 @@
 """H3VM rc5 runtime package. Heavy CUDA/Comfy imports remain lazy."""
+
+# Install the logical-device resolver before Core/loader compatibility wrappers
+# import and bind loader_base private helpers.
+from .gpu_preflight import install_gpu_preflight_patch as _install_gpu_preflight_patch
+_install_gpu_preflight_patch()
+del _install_gpu_preflight_patch
+
 from .core_adapter import install_runtime_bridge as _install_runtime_bridge
 _install_runtime_bridge()
 del _install_runtime_bridge

--- a/h3vm/gpu_preflight.py
+++ b/h3vm/gpu_preflight.py
@@ -1,0 +1,198 @@
+"""H3VM dual-GPU visibility and logical-device preflight.
+
+This module intentionally patches the small device-selection boundary instead of
+editing the frozen heavy runtime in ``loader_base.py``.  H3VM device options are
+logical CUDA indices as seen by the current ComfyUI/Python process.  Therefore a
+``CUDA_VISIBLE_DEVICES`` mask may renumber physical GPUs, and identical GPU model
+names are perfectly valid as long as two different logical devices are visible.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+_PATCH_FLAG = "_h3vm_gpu_preflight_v2_installed"
+_LOGGED_PAIRS: set[tuple[int, int]] = set()
+
+
+def _explicit_cuda_index(option):
+    """Return an explicit logical CUDA index for gpu:N / cuda:N options."""
+    if isinstance(option, int):
+        return option if option >= 0 else None
+    if isinstance(option, str):
+        text = option.strip().lower()
+        for prefix in ("gpu:", "cuda:"):
+            if text.startswith(prefix):
+                suffix = text.split(":", 1)[1].strip()
+                if suffix.isdigit():
+                    return int(suffix)
+    return None
+
+
+def _resolve_device(option):
+    """Resolve H3VM's explicit GPU choices as PyTorch-logical CUDA devices.
+
+    Explicit ``gpu:N`` / ``cuda:N`` values bypass ComfyUI's resolver so two
+    same-model cards cannot collapse onto a preferred/default device.  Other
+    option forms still delegate to ComfyUI for compatibility.
+    """
+    import torch
+
+    index = _explicit_cuda_index(option)
+    if index is not None:
+        return torch.device(f"cuda:{index}")
+    if isinstance(option, torch.device):
+        return option
+
+    import comfy.model_management
+
+    try:
+        resolved = comfy.model_management.resolve_gpu_device_option(option)
+    except Exception:
+        resolved = None
+    if resolved is None:
+        raise RuntimeError(f"H3VM cannot resolve device {option!r}")
+    return torch.device(resolved)
+
+
+def _visible_cuda_inventory(torch_module):
+    if not bool(torch_module.cuda.is_available()):
+        return []
+    try:
+        count = int(torch_module.cuda.device_count())
+    except Exception:
+        count = 0
+
+    inventory = []
+    for index in range(count):
+        name = "unknown"
+        total_gib = None
+        try:
+            name = str(torch_module.cuda.get_device_name(index))
+        except Exception:
+            pass
+        try:
+            total_gib = float(torch_module.cuda.get_device_properties(index).total_memory) / (1024 ** 3)
+        except Exception:
+            pass
+        inventory.append((index, name, total_gib))
+    return inventory
+
+
+def _format_visible(inventory):
+    if not inventory:
+        return "  (none)"
+    lines = []
+    for index, name, total_gib in inventory:
+        memory = f", {total_gib:.1f} GiB" if total_gib is not None else ""
+        lines.append(f"  cuda:{index} = {name}{memory}")
+    return "\n".join(lines)
+
+
+def _nvidia_smi_inventory():
+    """Best-effort physical inventory used only when PyTorch sees <2 GPUs."""
+    try:
+        proc = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,name,memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+    except Exception:
+        return ()
+    if proc.returncode != 0:
+        return ()
+    return tuple(line.strip() for line in proc.stdout.splitlines() if line.strip())
+
+
+def _common_preflight(primary_device, secondary_device):
+    import torch
+
+    cuda_available = bool(torch.cuda.is_available())
+    inventory = _visible_cuda_inventory(torch)
+    visible_count = len(inventory)
+    cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    nvidia_visible = os.environ.get("NVIDIA_VISIBLE_DEVICES")
+
+    if not cuda_available or visible_count < 2:
+        physical = _nvidia_smi_inventory()
+        message = [
+            "H3VM dual-GPU preflight failed.",
+            f"PyTorch CUDA available: {cuda_available}",
+            f"PyTorch-visible CUDA devices: {visible_count}",
+            f"CUDA_VISIBLE_DEVICES={cuda_visible!r}",
+            f"NVIDIA_VISIBLE_DEVICES={nvidia_visible!r}",
+            "Visible devices:",
+            _format_visible(inventory),
+        ]
+        if physical:
+            message.append("System GPUs reported by nvidia-smi:")
+            message.extend(f"  {row}" for row in physical)
+        message.extend(
+            [
+                "H3VM supports identical GPU model names (for example two RTX 3080s).",
+                "The two selected GPUs must both be visible to this ComfyUI/Python process.",
+            ]
+        )
+        if cuda_visible not in (None, "", "-1"):
+            message.append(
+                "CUDA_VISIBLE_DEVICES is set. Restart ComfyUI with both target GPUs exposed "
+                "(for example CUDA_VISIBLE_DEVICES=0,1), then select gpu:0 + gpu:1 inside H3VM."
+            )
+        else:
+            message.append(
+                "Verify the NVIDIA driver/startup environment, restart ComfyUI, and confirm "
+                "torch.cuda.device_count() is at least 2 before using a dual-GPU mode."
+            )
+        raise RuntimeError("\n".join(message))
+
+    primary = _resolve_device(primary_device)
+    secondary = _resolve_device(secondary_device)
+
+    for label, device in (("primary", primary), ("secondary", secondary)):
+        if device.type != "cuda":
+            raise RuntimeError(f"H3VM {label} device must be CUDA, got {device}")
+        if device.index is None or device.index < 0 or device.index >= visible_count:
+            raise RuntimeError(
+                f"H3VM {label} device {device} is outside the {visible_count} CUDA devices visible "
+                "to this ComfyUI process. H3VM uses logical indices after CUDA_VISIBLE_DEVICES."
+            )
+
+    if primary == secondary:
+        raise RuntimeError(
+            f"H3VM needs two different logical CUDA devices, got {primary} and {secondary}. "
+            "Identical GPU model names are supported; choose two different indices such as gpu:0 and gpu:1."
+        )
+
+    pair = (int(primary.index), int(secondary.index))
+    if pair not in _LOGGED_PAIRS:
+        primary_name = str(torch.cuda.get_device_name(primary))
+        secondary_name = str(torch.cuda.get_device_name(secondary))
+        same_model = primary_name == secondary_name
+        print(
+            f"[H3VM GPU PREFLIGHT] visible={visible_count} | "
+            f"primary={primary} ({primary_name}) | secondary={secondary} ({secondary_name}) | "
+            f"identical_models={'yes' if same_model else 'no'} | "
+            f"CUDA_VISIBLE_DEVICES={cuda_visible!r}",
+            flush=True,
+        )
+        _LOGGED_PAIRS.add(pair)
+
+    return primary, secondary
+
+
+def install_gpu_preflight_patch():
+    """Install the improved resolver/preflight before Core/loader wrappers bind."""
+    from . import loader_base
+
+    if bool(getattr(loader_base, _PATCH_FLAG, False)):
+        return
+    loader_base._resolve_device = _resolve_device
+    loader_base._common_preflight = _common_preflight
+    setattr(loader_base, _PATCH_FLAG, True)

--- a/tests/test_gpu_preflight_contract.py
+++ b/tests/test_gpu_preflight_contract.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import types
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "h3vm" / "gpu_preflight.py"
+spec = importlib.util.spec_from_file_location("h3vm_gpu_preflight_contract", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+assert mod._explicit_cuda_index("gpu:0") == 0
+assert mod._explicit_cuda_index("GPU:1") == 1
+assert mod._explicit_cuda_index("cuda:12") == 12
+assert mod._explicit_cuda_index(3) == 3
+assert mod._explicit_cuda_index(-1) is None
+assert mod._explicit_cuda_index("gpu:x") is None
+assert mod._explicit_cuda_index("default") is None
+
+visible = mod._format_visible([
+    (0, "NVIDIA GeForce RTX 3080", 10.0),
+    (1, "NVIDIA GeForce RTX 3080", 10.0),
+])
+assert visible.count("RTX 3080") == 2
+assert "cuda:0" in visible and "cuda:1" in visible
+
+
+class _FakeCuda:
+    @staticmethod
+    def is_available():
+        return True
+
+    @staticmethod
+    def device_count():
+        return 1
+
+    @staticmethod
+    def get_device_name(index):
+        assert index == 0
+        return "NVIDIA GeForce RTX 3080"
+
+    @staticmethod
+    def get_device_properties(index):
+        assert index == 0
+        return types.SimpleNamespace(total_memory=10 * 1024**3)
+
+
+old_torch = sys.modules.get("torch")
+old_cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+old_smi = mod._nvidia_smi_inventory
+try:
+    sys.modules["torch"] = types.SimpleNamespace(cuda=_FakeCuda())
+    os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+    mod._nvidia_smi_inventory = lambda: (
+        "0, NVIDIA GeForce RTX 3080, 10240",
+        "1, NVIDIA GeForce RTX 3080, 10240",
+    )
+    try:
+        mod._common_preflight("gpu:0", "gpu:1")
+        raise AssertionError("preflight should fail when only one logical CUDA device is visible")
+    except RuntimeError as exc:
+        text = str(exc)
+        assert "PyTorch-visible CUDA devices: 1" in text
+        assert "CUDA_VISIBLE_DEVICES='0'" in text
+        assert "two RTX 3080s" in text
+        assert "nvidia-smi" in text
+        assert "gpu:0 + gpu:1" in text
+finally:
+    mod._nvidia_smi_inventory = old_smi
+    if old_torch is None:
+        sys.modules.pop("torch", None)
+    else:
+        sys.modules["torch"] = old_torch
+    if old_cuda_visible is None:
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+    else:
+        os.environ["CUDA_VISIBLE_DEVICES"] = old_cuda_visible
+
+print("gpu preflight contract: ok")


### PR DESCRIPTION
Fixes the public dual-GPU preflight without modifying the frozen heavy runtime in `loader_base.py`.

Changes:
- resolve explicit `gpu:N` / `cuda:N` as PyTorch-logical CUDA devices before ComfyUI fallback resolution;
- explicitly support identical GPU model pairs such as two RTX 3080s;
- replace the generic `<2 GPUs` error with actionable visibility diagnostics including CUDA masks, visible GPU names/VRAM, and best-effort `nvidia-smi` inventory;
- log the resolved primary/secondary pair once on successful preflight;
- install the compatibility patch before Core/loader wrappers bind helpers;
- add a lightweight contract test and CI coverage;
- document logical CUDA indexing in Chinese and English READMEs.

The fix cannot expose a GPU hidden by the startup environment inside an already-running process. If `CUDA_VISIBLE_DEVICES` exposes only one card, the new error explains that ComfyUI must be restarted with both target GPUs visible.